### PR TITLE
Change UndeployPowerAction behaviour

### DIFF
--- a/lib/vcloud/cli/utils/make_vapp_template.rb
+++ b/lib/vcloud/cli/utils/make_vapp_template.rb
@@ -57,7 +57,8 @@ module Vcloud
             vcloud.process_task(task)
 
             puts "Stopping vApp completely"
-            task = vcloud.post_undeploy_vapp(vapp.id).body
+            options = { :UndeployPowerAction => 'shutdown' }
+            task = vcloud.post_undeploy_vapp(vapp.id, options).body
             vcloud.process_task(task)
 
             puts "Turn the newly provisioned vApp into a vAppTemplate (in vDC #{vdc_name})"

--- a/lib/vcloud/cli/utils/stop_vapp.rb
+++ b/lib/vcloud/cli/utils/stop_vapp.rb
@@ -20,7 +20,8 @@ module Vcloud
               vapp = Vcloud::Core::Vapp.get_by_name(identifier)
             end
             Fog.mock! if ENV['FOG_MOCK']
-            task = vcloud.post_undeploy_vapp(vapp.id).body
+            options = { :UndeployPowerAction => 'shutdown' }
+            task = vcloud.post_undeploy_vapp(vapp.id, options).body
             vcloud.process_task(task)
           end
 


### PR DESCRIPTION
UndeployPowerAction is documented here:
http://pubs.vmware.com/vcd-55/index.jsp?topic=%2Fcom.vmware.vcloud.api.reference.doc_55%2Fdoc%2Ftypes%2FUndeployVAppParamsType.html

There are a number of values that can be passed to it, including Shutdown
and PowerOff. PowerOff and Shutdown differ in that the former is the
equivalent of pulling the power out at the wall on a physical machine, and
Shutdown performs a graceful shutdown of the vApp which then performs a
graceful shutdown of the VM. The default action for the UndeployPowerAction
call is PowerOff.

Until now, we've been relying on the default value of PowerOff rather than
Shutdown, which isn't the nicest way to turn machines off. Fixes this to
make clean boots a thing.

---

I've not made this change in `lib/vcloud/cli/utils/delete_vapp.rb`, because if you're deleting a vApp, you probably don't care about how the VM(s) within were shutdown.
